### PR TITLE
Replace OpenTracing error logs with SignalFx tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.pyc
+.pytest_cache/
+.cache/
 dist
 bin
 eggs
@@ -6,3 +8,6 @@ lib
 *.egg-info
 build
 env/
+venv/
+.vscode
+.python-version

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -108,16 +108,20 @@ class TestPipeline(unittest.TestCase):
             self.assertEqual(len(self.tracer.finished_spans()), 1)
             span = self.tracer.finished_spans()[0]
             self.assertEqual(span.operation_name, 'MULTI')
-            self.assertEqual(span.tags, {
+            tags = {
                 'component': 'redis-py',
                 'db.type': 'redis',
                 'db.statement': 'LPUSH my:keys 1 3;LPUSH my:keys 5 7',
                 'span.kind': 'client',
                 'error': True,
-            })
-            self.assertEqual(len(span.logs), 1)
-            self.assertEqual(span.logs[0].key_values.get('event', None),
-                             'error')
-            self.assertTrue(isinstance(
-                span.logs[0].key_values.get('error.object', None), ValueError
-            ))
+            }
+
+            for k, v in tags.items():
+                assert k in span.tags
+                assert span.tags[k] == v
+
+            self.assertEqual(span.tags['error'], True)
+            self.assertEqual(span.tags['sfx.error.message'], '')
+            self.assertEqual(span.tags['sfx.error.kind'], 'ValueError')
+            self.assertEqual(span.tags['sfx.error.object'], '<class \'ValueError\'>')
+            assert len(span.tags['sfx.error.stack']) > 50

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -115,16 +115,20 @@ class TestPubSub(unittest.TestCase):
             self.assertEqual(len(self.tracer.finished_spans()), 1)
             span = self.tracer.finished_spans()[0]
             self.assertEqual(span.operation_name, 'SUB')
-            self.assertEqual(span.tags, {
+            tags = {
                 'component': 'redis-py',
                 'db.type': 'redis',
                 'db.statement': '',
                 'span.kind': 'client',
                 'error': True,
-            })
-            self.assertEqual(len(span.logs), 1)
-            self.assertEqual(span.logs[0].key_values.get('event', None),
-                             'error')
-            self.assertTrue(isinstance(
-                span.logs[0].key_values.get('error.object', None), ValueError
-            ))
+            }
+
+            for k, v in tags.items():
+                assert k in span.tags
+                assert span.tags[k] == v
+
+            self.assertEqual(span.tags['error'], True)
+            self.assertEqual(span.tags['sfx.error.message'], '')
+            self.assertEqual(span.tags['sfx.error.kind'], 'ValueError')
+            self.assertEqual(span.tags['sfx.error.object'], '<class \'ValueError\'>')
+            assert len(span.tags['sfx.error.stack']) > 50


### PR DESCRIPTION
This PR changes how errors are recorded on spans. It uses the new
SignalFx semantic convention and records the errors as attributes
instead of logs.